### PR TITLE
Allow https:// and ssh:// scm uris

### DIFF
--- a/github-release-plugin/src/test/kotlin/utils.kt
+++ b/github-release-plugin/src/test/kotlin/utils.kt
@@ -9,5 +9,11 @@ class TestSCMParse {
         assertEquals(
                 Repo("https://api.github.com", "cy6erGn0m", "github-release-plugin"),
                 "scm:git:git@github.com:cy6erGn0m/github-release-plugin.git".parseSCMUrl())
+        assertEquals(
+                Repo("https://api.github.com", "cy6erGn0m", "github-release-plugin"),
+                "scm:git:https://github.com/cy6erGn0m/github-release-plugin.git".parseSCMUrl())
+        assertEquals(
+                Repo("https://api.github.com", "cy6erGn0m", "github-release-plugin"),
+                "scm:git:ssh://git@github.com/cy6erGn0m/github-release-plugin.git".parseSCMUrl())
     }
 }

--- a/github-release-shared/src/main/kotlin/util.kt
+++ b/github-release-shared/src/main/kotlin/util.kt
@@ -11,6 +11,6 @@ internal fun JSONObject.getAsLong(key: String) = (get(key) as? Number)?.toLong()
 internal fun Reader.toJSONObject(): JSONObject? = JSONParser().parse(this) as? JSONObject
 
 fun String.parseSCMUrl(): Repo? =
-        "^scm:git:([^@]+@)?(https?://)?([^:]+):([^/]+)/([^/]+)\\.git".toRegex().matchEntire(this)?.let { match ->
+        "^scm:git:([^@]+@)?(ssh://|https?://)?([^:]+)[:/]([^/]+)/([^/]+)\\.git".toRegex().matchEntire(this)?.let { match ->
             Repo(endpointOf(match.groups[2]?.value, match.groups[3]!!.value), match.groups[4]!!.value, match.groups[5]!!.value)
         }


### PR DESCRIPTION
Previously, only scm uris with format `scm:git:git@github.com:user/repo.git` worked.

This PR changes the regex so that both `scm:git:https://github.com/user/repo.git` and `scm:git:ssh://git@github.com/user/repo.git` work, too.